### PR TITLE
Update lib.php

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -2180,6 +2180,10 @@ class enrol_oss_plugin extends enrol_plugin {
         // are syncing a lot of users (as we try to open a new connection
         // to get the user details). This is the least invasive way
         // to reuse existing connections without greater code surgery.
+        $rp = new ReflectionProperty($authldap,'ldapconns');
+        if ($rp->isProtected()) {
+            return $authldap->ldap_connect();
+        }
         if(!empty($authldap->ldapconnection)) {
             $authldap->ldapconns++;
             return $authldap->ldapconnection;


### PR DESCRIPTION
Hallo Frank,

nach einem Update auf Moodle 4.2.1 funktionierte der Login nicht mehr. In der neuen Version des ldap Plugins wurde ldapconns auf protected gesetzt und konnte nicht mehr verändert werden. Gleichzeitig gibt es aber die Methode ldap_connect im Plugin, welche im Grunde das gleiche macht, wie die Methode ldap_connect_ul. Vielleicht ist der Grund für deine Wrapper Funktion inzwischen auch hinfällig? Jedenfalls habe ich einen check zu Beginn eingebaut, der schaut, ob ldapconns protected ist und wenn ja die ldap_connect Methode des LDAP Plugins aufruft.

Lg
Martin